### PR TITLE
fix for ESP-IDF 5.2

### DIFF
--- a/NMEA2000_esp32_twai.cpp
+++ b/NMEA2000_esp32_twai.cpp
@@ -139,7 +139,7 @@ bool NMEA2000_esp32_twai::CANGetFrame(unsigned long &id, unsigned char &len, uns
         id = message.identifier;
         len = message.data_length_code;
         memcpy(buf, message.data,message.data_length_code);
-        ESP_LOGD(TAG,"Got side message id=%08lX, len=%d, data=%08X", id, len, (uint32_t)*buf);
+        ESP_LOGD(TAG,"Got side message id=%08lX, len=%d, data=%08lX", id, len, (uint32_t)*buf);
         return true;
     }
 
@@ -148,7 +148,7 @@ bool NMEA2000_esp32_twai::CANGetFrame(unsigned long &id, unsigned char &len, uns
         id = message.identifier;
         len = message.data_length_code;
         memcpy(buf, message.data,message.data_length_code);
-        ESP_LOGD(TAG,"Message received id=%08lX, len=%d, data=%08X", id, len, (uint32_t)*buf);
+        ESP_LOGD(TAG,"Message received id=%08lX, len=%d, data=%08lX", id, len, (uint32_t)*buf);
 
         // Send frame to listeners
         for(int i = 0; i < m_listenerCount; i++){


### PR DESCRIPTION
Fix to enable compilation with ESP-IDF 5.2.

ESP_LOGD expects "%lX" for uint32_t